### PR TITLE
changing which boundaries are loaded

### DIFF
--- a/app.R
+++ b/app.R
@@ -21,9 +21,9 @@ library(lubridate)
 library(dplyr)
 
 # load boundry data from files and rename
-ltla_bounds <- readRDS(file = "ltla21_boundaries.rds")
-ltla_bounds = ltla_bounds %>%
-  rename(areaName="ltla21_name",areaCode="ltla21_code")
+load("boundaries_ltla19.rda")
+ltla_bounds = boundaries_ltla19 %>%
+  rename(areaName="ltla19_name",areaCode="ltla19_code")
 #load covid data
 ltlaC19 <- read_csv("covid_ltla_2022-05-16.csv")
 


### PR DESCRIPTION
Changing the data load to use 2019 LTLA boundaries instead of 2021, as extensive checking shows that the covid data matches the 2019 boundaries (it is only missing scilly isles and city of london, which were presumably excluded due to size)